### PR TITLE
Renamed functions to suppress warnings about ambigious naming in cate…

### DIFF
--- a/Quantcast-iOS-Measurement/Optional/QuantcastMeasurement+Networks.m
+++ b/Quantcast-iOS-Measurement/Optional/QuantcastMeasurement+Networks.m
@@ -48,9 +48,9 @@
             return nil;
         }
         
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(terminateNotification) name:UIApplicationWillTerminateNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseNotification) name:UIApplicationDidEnterBackgroundNotification object:nil];
-        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resumeNotification) name:UIApplicationWillEnterForegroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(terminateNotificationNetworks) name:UIApplicationWillTerminateNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(pauseNotificationNetworks) name:UIApplicationDidEnterBackgroundNotification object:nil];
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(resumeNotificationNetworks) name:UIApplicationWillEnterForegroundNotification object:nil];
         
         NSMutableArray* labels = [NSMutableArray array];
         if ([inAppLabelsOrNil isKindOfClass:[NSArray class]]) {
@@ -67,15 +67,15 @@
     return userhash;
 }
 
--(void)terminateNotification{
+-(void)terminateNotificationNetworks{
     [self internalEndMeasurementSessionWithAppLabels:nil networkLabels:nil];
 }
 
--(void)pauseNotification{
+-(void)pauseNotificationNetworks{
     [self internalPauseSessionWithAppLabels:nil networkLabels:nil];
 }
 
--(void)resumeNotification{
+-(void)resumeNotificationNetworks{
     [self internalResumeSessionWithAppLabels:nil networkLabels:nil];
 }
 


### PR DESCRIPTION
http://stackoverflow.com/questions/9424004/suppress-warning-category-is-implementing-a-method-which-will-also-be-implement

The terminateNotification pauseNotification and resumeNotification cause a warning in XCode where it becomes ambiguous which method should be used (from QuantcastMeasurement or the category). Renamed the function names to make it explicit. Compiler warnings no longer show